### PR TITLE
fix multiple picker issue on iOS

### DIFF
--- a/ios/ImageCropPicker.m
+++ b/ios/ImageCropPicker.m
@@ -409,8 +409,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
      }];
 }
 
-- (NSArray*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withData:(NSString*)data {
-    return @[@{
+- (NSDictionary*) createAttachmentResponse:(NSString*)filePath withExif:(NSDictionary*) exif withSourceURL:(NSString*)sourceURL withLocalIdentifier:(NSString*)localIdentifier withFilename:(NSString*)filename withWidth:(NSNumber*)width withHeight:(NSNumber*)height withMime:(NSString*)mime withSize:(NSNumber*)size withData:(NSString*)data {
+    return @{
              @"path": filePath,
              @"sourceURL": (sourceURL) ? sourceURL : [NSNull null],
              @"localIdentifier": (localIdentifier) ? localIdentifier : [NSNull null],
@@ -421,7 +421,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
              @"size": size,
              @"data": (data) ? data : [NSNull null],
              @"exif": (exif) ? exif : [NSNull null],
-             }];
+             };
 }
 
 - (void)qb_imagePickerController:


### PR DESCRIPTION
# iOS
- [多图片选择时](https://github.com/mg365/react-native-customized-image-picker/blob/master/ios/ImageCropPicker.m#L504)，返回的是二维数组： [[{}], [{}], [{}]]
- [多视频选择时](https://github.com/mg365/react-native-customized-image-picker/blob/master/ios/ImageCropPicker.m#L459)，返回是的一维数组：[{}, {}]

# Android
- 多图片/视频选择 返回的是一维数组：[{}, {}]

希望可以统一返回一维数组：[{}, {}]
