### PR TITLE
Update manifest file for compatibility with AAPT2

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mg.app">
-
+    
+    <uses-feature android:name="android.hardware.camera" android:required="true"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    
     <application>
-        <uses-feature android:name="android.hardware.camera" android:required="true"/>
-        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-
         <activity android:name="cn.finalteam.rxgalleryfinal.ui.activity.MediaActivity"
                   android:screenOrientation="portrait"
                   android:exported="true"


### PR DESCRIPTION
This AdroidManifest.xml file is not compatible with AAPT2, the [new file structure](https://developer.android.com/guide/topics/manifest/manifest-intro#filestruct) requires that the [`uses-permission`](https://developer.android.com/guide/topics/manifest/uses-permission-element) and [`uses-feature`](https://developer.android.com/guide/topics/manifest/uses-feature-element) elements to be inserted as children of the `manifest` element instead of the `application` element.